### PR TITLE
allows compare() to work with do.call()

### DIFF
--- a/R/compare.r
+++ b/R/compare.r
@@ -17,8 +17,13 @@ compare <- function( ... , n=1e3 , sort="WAIC" , WAIC=TRUE , refresh=0 ) {
         L <- L[[1]]
     
     # retrieve model names from function call
+    # if names of the call are set (as would be with a do.call())
+    # use those rather than coercing match.call() to character
     mnames <- match.call()
-    mnames <- as.character(mnames)[2:(length(L)+1)]
+    if (!is.null(names(mnames)))
+      mnames <- names(mnames)[2:(length(L)+1)]
+    else
+      mnames <- as.character(mnames)[2:(length(L)+1)]
     
     dSE.matrix <- matrix( NA , nrow=length(L) , ncol=length(L) )
     if ( WAIC==FALSE ) {


### PR DESCRIPTION
If this is helpful, here's a commit that solves the `do.call()` issue I emailed about. Here's an example showing it works (and didn't break anything):

     > f1 = fits1$m1
     > f2 = fits1$m2
     > compare(f1, f2)
          WAIC pWAIC dWAIC weight    SE   dSE
     f2 2150.1   5.3     0      1 22.66    NA
     f1 2395.1   3.3   245      0 22.83 16.76
    > do.call(compare, list(f1=fits1$m1, f2=fits1$m2))
          WAIC pWAIC dWAIC weight    SE   dSE
     f2 2150.5   5.5   0.0      1 22.58    NA
     f1 2395.4   3.4 244.8      0 22.93 16.94
    > compare(a=f1, b=f2)   # trying to break it; still works
         WAIC pWAIC dWAIC weight    SE   dSE
     b 2150.4   5.5   0.0      1 22.69    NA
     a 2395.7   3.6 245.3      0 23.17 17.14
