### PR TITLE
Check for sufficient samples with extract.samples() from map2stan object

### DIFF
--- a/R/map2stan-class.r
+++ b/R/map2stan-class.r
@@ -26,6 +26,11 @@ function(object,n,...) {
     }
     if ( !missing(n) ) {
         for ( i in 1:length(p) ) {
+            # Check that n is not greater than the number of samples
+            # returned by rstan::extract()
+            if (n > nrow(p[[i]])) {
+                stop("n is greater than the number of samples present.\nConsider using rethinking::resample() with a larger value for 'iter'.")
+            }
             n_dims <- length( dim(p[[i]]) )
             if ( n_dims==1 ) p[[i]] <- p[[i]][1:n]
             if ( n_dims==2 ) p[[i]] <- p[[i]][1:n,]


### PR DESCRIPTION
`rstan::extract()` returns only the samples present in `object@stanfit`. It is possible to request more samples with `rethinking::extract.samples()` than are present (i.e., n > (iter - startup)), resulting in an out of bounds error. Here is a minimal example:

```
library(rethinking)
data("Howell1")

d <- Howell1
d2 <- d[ d$age >= 18 , ]
d2$male <- coerce_index(d2$male)

m1 <- map2stan(
  alist(
    height ~ dnorm(mu, sigma),
    mu <- a[male] + b_weight * weight,
    b_weight ~ dnorm(0, 5),
    a[male] ~ dnorm(120, 5),
    sigma ~ dunif(0, 50)
  ),
  data = d2,
  iter = 2000,
  warmup = 1000
)

str(extract.samples(m1))

str(extract.samples(m1, n = 1e4))
```

If `n` < (iter - startup), this does not fail. n > (iter - startup) errors with `Error in p[[i]][1:n, ] : subscript out of bounds`.

This pull request adds a check for this condition and suggests that the user resample the model with more iterations.
