### PR TITLE
Bug in error checking of class(data) in map() and map2stan()

### DIFF
--- a/R/map.r
+++ b/R/map.r
@@ -36,7 +36,8 @@ map <- function( flist , data , start , method="BFGS" , hessian=TRUE , debug=FAL
     }
     if ( missing(start) ) start <- list()
     if ( missing(data) ) stop( "'data' required." )
-    if ( !( class(data) %in% c("list","data.frame") ) ) {
+    ## if ( !( class(data) %in% c("list","data.frame") ) ) {
+    if ( ! ( ("data.frame" %in% class(data) ) || ("list" %in% class(data) ) ) ) {
         stop( "'data' must be of class list or data.frame." )
     }
     

--- a/R/map.r
+++ b/R/map.r
@@ -36,7 +36,6 @@ map <- function( flist , data , start , method="BFGS" , hessian=TRUE , debug=FAL
     }
     if ( missing(start) ) start <- list()
     if ( missing(data) ) stop( "'data' required." )
-    ## if ( !( class(data) %in% c("list","data.frame") ) ) {
     if ( ! ( ("data.frame" %in% class(data) ) || ("list" %in% class(data) ) ) ) {
         stop( "'data' must be of class list or data.frame." )
     }

--- a/R/map2stan.r
+++ b/R/map2stan.r
@@ -71,7 +71,7 @@ map2stan <- function( flist , data , start , pars , constraints=list() , types=l
         }
     }
     if ( missing(data) ) stop( "'data' required." )
-    if ( !( class(data) %in% c("list","data.frame") ) ) {
+    if ( ! ( ("data.frame" %in% class(data) ) || ("list" %in% class(data) ) ) ) {    
         stop( "'data' must be of class list or data.frame." )
     }
     


### PR DESCRIPTION
Currently, the functions `map()` and `map2stan()` check that the `data` argument supplied to the function is of type data.frame or list.  

```r
    if ( !( class(data) %in% c("list","data.frame") ) ) {
        stop( "'data' must be of class list or data.frame." )
    }
```

This implementation assumes that `class()` returns a vector of length one, which is not the case for any objects that inherit from data.frame, such as [tibbles](https://github.com/tidyverse/tibble), which are widely used in R tidyverse data-manipulation packages such as dplyr.

```r
class(dplyr::as_data_frame(mtcars))
##  [1] "tbl_df"     "tbl"        "data.frame"
```

Despite a tibble being a special type of data.frame, running `map()` with a tibble yields the error:

```
Error in map  :
 'data' must be of class list or data.frame.
 In addition: Warning message:
 In if (!(class(data) %in% c("list", "data.frame"))) { :
   the condition has length > 1 and only the first element will be used
```

This pull request corrects this bug.  Here is code to demonstrate it works.

```r
library("rethinking")
library("dplyr")  ## for data manipulation                                                                    

## based on R code 4.29 from page 88                                                                          
data(Howell1)

## regular data.frame version                                                                                 
d <- Howell1
dregular <- d[ d$age >= 18, ]

## tibble version                                                                                             
dtibble <- Howell1 %>%
  as_data_frame() %>%
  filter(age >= 18)

class(dregular)
## [1] "data.frame"                                                                                           

class(dtibble)
## [1] "tbl_df"     "tbl"        "data.frame"                                                                 

## fit model with regular data.frame                                                                          
m4.2 <- map(alist(height ~ dnorm(mu, sigma),
                  mu ~ dnorm(178, 0.1),
                  sigma ~ dunif(0, 50)),
            data = dregular)

## fit model with tibble                                                                                      
m4.2 <- map(alist(height ~ dnorm(mu, sigma),
                  mu ~ dnorm(178, 0.1),
                  sigma ~ dunif(0, 50)),
            data = dtibble)
## succeeds, where previously would have given an error message
```