### PR TITLE
replace use of class() == with inherits() and a few other improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,3 +9,5 @@ Imports: coda, MASS, mvtnorm, loo
 Depends: rstan (>= 2.10.0), parallel, methods, stats, graphics
 Description: Utilities for fitting and comparing models
 License: GPL (>= 3)
+LazyLoad: yes
+LazyData: yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: rethinking
 Type: Package
 Title: Statistical Rethinking book package
-Version: 1.59
+Version: 1.59.9000
 Date: 2016-6-24
 Author: Richard McElreath
-Maintainer: Richard McElreath <mcelreath@ucdavis.edu>
+Maintainer: Randall Pruim <rpruim@calvin.edu>
 Imports: coda, MASS, mvtnorm, loo
 Depends: rstan (>= 2.10.0), parallel, methods, stats, graphics
 Description: Utilities for fitting and comparing models

--- a/R/densify.R
+++ b/R/densify.R
@@ -1,0 +1,9 @@
+
+
+densify <- function(x, y) {
+  if ( diff(range(diff(x))) > 0.1 * min(abs(diff(x))) )
+    stop("`x` must be (approximately) equally spaced.")
+
+  width <- mean(diff(x))
+  y / sum(y) / width
+}

--- a/R/densify.R
+++ b/R/densify.R
@@ -1,4 +1,17 @@
-
+#' Turn "rasterized" kernel into "rasterized" density function
+#'
+#' Turn "rasterized" kernel into "rasterized" density function
+#'
+#' @param x,y numerical vectors of equal length giving the (x, y) coordinates
+#'        of a kernel function \code{k} with \code{k(x) = y}.
+#' @return a rescaled version of \code{y} that turns the kernel into a pdf.
+#' @examples
+#' x <- seq(0, 1, by = 0.05)
+#' y1 <- (x - 0.5)^2
+#' y2 <- densify(x, y1)
+#' if (require(lattice)) {
+#'   xyplot(y1 + y2 ~ x, type = "l")
+#' }
 
 densify <- function(x, y) {
   if ( diff(range(diff(x))) > 0.1 * min(abs(diff(x))) )

--- a/R/fits-and-resids.R
+++ b/R/fits-and-resids.R
@@ -1,0 +1,12 @@
+fitted.map <- function(object, n = 1e3, data = object@data, ..., na.rm = TRUE) {
+  apply(link(object, n = n, data = data, ...), 2, mean, na.rm = na.rm)
+}
+
+residuals.map <- function(object, n = 1e3, data = object@data, fits = NULL, ..., na.rm = TRUE){
+  if (is.null(fits)) {
+    fits <- fitted(object, n=n, data = data, ..., na.rm = na.rm)
+  }
+  outcome_name <- object@formula[[1]][[2]]
+  message("Residuals computed assuming outcome = ", as.character(outcome_name))
+  eval(outcome_name, data) - fits
+}

--- a/R/plotting.r
+++ b/R/plotting.r
@@ -10,7 +10,6 @@ set_nice_margins <- function() {
 }
 
 dens <- function( x , adj=0.5 , norm.comp=FALSE , main="" , show.HPDI=FALSE , show.zero=FALSE , rm.na=TRUE , add=FALSE , ...) {
-    the.class <- class(x)[1]  # unnecessary now that we are using inherits()
     if ( inherits(x, "data.frame") ) {
         # full posterior
         n <- ncol(x)

--- a/R/plotting.r
+++ b/R/plotting.r
@@ -10,8 +10,8 @@ set_nice_margins <- function() {
 }
 
 dens <- function( x , adj=0.5 , norm.comp=FALSE , main="" , show.HPDI=FALSE , show.zero=FALSE , rm.na=TRUE , add=FALSE , ...) {
-    the.class <- class(x)[1]
-    if ( the.class=="data.frame" ) {
+    the.class <- class(x)[1]  # unnecessary now that we are using inherits()
+    if ( inherits(x, "data.frame") ) {
         # full posterior
         n <- ncol(x)
         cnames <- colnames(x)
@@ -121,7 +121,7 @@ show.naive.posterior <- function( est , se , model=NULL , level=0.95 , xlab="est
     }
     plot( 0 , 0 , type="n" , xlab=xlab , ylab=ylab , ylim=c(ciy,maxy) , xlim=c(minx,maxx) , yaxp=c(0,maxy,4) , yaxt=yaxistype , ... )
     if ( zero.lines==TRUE ) {
-        if ( show.density==TRUE ) 
+        if ( show.density==TRUE )
             lines( c(minx-abs(minx),maxx+abs(maxx)) , c(0,0) , lty=3 )
         lines( c(0,0) , c(-1,maxy*2) , lty=3 )
     }
@@ -203,7 +203,7 @@ simplehist_old <- function( x , ylab="Frequency" , xlab="Count" , ycounts=TRUE ,
        set_nice_margins()
        plot( density( x , adjust=adjust ) , ylab=ylab , xlab=xlab , ... )
     }
-    
+
 }
 
 ####

--- a/R/precis.r
+++ b/R/precis.r
@@ -1,6 +1,6 @@
 # my model summary function, précis
 
-precis.whitelist <- data.frame(
+precis.whitelist <- data.frame(stringsAsFactors = FALSE,
     class=c("map","map2stan","lm","glm","mle2","mer","bmer","polr","data.frame","clmm","clmm2","list","stanfit","lmerMod","glmerMod") ,
     coef.method=c("coef","coef","coef","coef","coef","fixef.plus","fixef.plus","polr","chain","coef","coef","mcarray","stanfit","fixef.plus","fixef.plus") ,
     vcov.method=c("vcov","vcov","vcov","vcov","vcov","vcov.VarCorr","vcov.VarCorr","vcov","chain","vcov","vcov","mcarray","stanfit","vcov.VarCorr","vcov.VarCorr") ,
@@ -119,7 +119,7 @@ precis <- function( model , depth=1 , pars , ci=TRUE , prob=0.89 , corr=FALSE , 
             result <- postlistprecis( post , prob=prob )
         }
     }
-    if ( iherits(model, c("map2stan", "stanfit")) ) {
+    if ( inherits(model, c("map2stan", "stanfit")) ) {
         # add n_eff to result
         #require(rstan)
         if ( inherits(model, "map2stan") )

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -16,11 +16,11 @@ blank <- function(ex=1,w=1,h=1) {
 
 # default pdf plot size, for making cmyk figures
 # close file with dev.off() as usual
-pdfblank <- function (ex = 1, w = 1, h = 1, colormodel="cmyk" , ... ) 
+pdfblank <- function (ex = 1, w = 1, h = 1, colormodel="cmyk" , ... )
 {
-    pdf("mypdf.pdf", width = 3.5 * ex * w, height = 3.5 * ex * 
+    pdf("mypdf.pdf", width = 3.5 * ex * w, height = 3.5 * ex *
         h , colormodel=colormodel , ...)
-    par(mgp = c(1.5, 0.5, 0), mar = c(2.5, 2.5, 2, 1) + 0.1, 
+    par(mgp = c(1.5, 0.5, 0), mar = c(2.5, 2.5, 2, 1) + 0.1,
         tck = -0.02)
 }
 
@@ -88,7 +88,7 @@ progbar <- function( current , min=0 , max=100 , starttime , update.interval=100
 covmat <- function( m , digits=4 ) {
     # upper diag is covariances
     # lower diag is correlations
-    if ( class(m)[1]=="data.frame" ) mcov <- cov( m ) else mcov <- vcov(m)
+    mcov <- if ( inherits(m, "data.frame") ) cov(m) else vcov(m)
     mcor <- cov2cor( mcov )
     mcov[ lower.tri(mcov) ] <- NA
     mcor[ lower.tri(mcor) ] <- NA
@@ -111,9 +111,9 @@ chainmode <- function( chain , ... ) {
 PIprimes <- c(0.67,0.89,0.97) # my snarky prime valued percentiles
 HPDI <- function( samples , prob=0.89 ) {
     # require(coda)
-    class.samples <- class(samples)[1]
+    ## class.samples <- class(samples)[1]  # not needed now that we are using inherits()
     coerce.list <- c( "numeric" , "matrix" , "data.frame" , "integer" , "array" )
-    if ( class.samples %in% coerce.list ) {
+    if ( inherits(samples, coerce.list) ) {
         # single chain for single variable
         samples <- coda::as.mcmc( samples )
     }
@@ -203,8 +203,8 @@ replicate2 <- function (n, expr, interval=0.1, simplify = "array") {
             cat( paste( "[" , i , "/" , n , "]\r" ) )
         }
     }
-    result <- sapply(1:n, 
-        eval.parent(substitute(function(i,...) { show_progress(i); expr })), 
+    result <- sapply(1:n,
+        eval.parent(substitute(function(i,...) { show_progress(i); expr })),
         simplify = simplify)
     cat("\n")
     result
@@ -219,7 +219,7 @@ mcreplicate <- function (n, expr, refresh = 0.1, mc.cores=2 ) {
             cat(paste("[", i, "/", n, "]\r"))
         }
     }
-    result <- simplify2array(mclapply(1:n, eval.parent(substitute(function(i, 
+    result <- simplify2array(mclapply(1:n, eval.parent(substitute(function(i,
         ...) {
         if (refresh>0) show_progress(i)
         expr
@@ -266,7 +266,7 @@ coerce_index <- function( ... ) {
         }
         names(M) <- paste( vnames , "_idx" , sep="" )
         return(M)
-    } 
+    }
 }
 
 # sd and var functions that don't use n-1 denominator
@@ -285,11 +285,11 @@ var2 <- function( x , na.rm=TRUE ) {
 # name 'default__' is default digits
 # so can pass e.g. digits=c( 'default__'=2 , n_eff=0 )
 format_show <- function( x , digits ) {
-    r <- as.data.frame(lapply( 1:length(x) , 
-        function(i) { 
-            if ( names(x)[i] %in% names(digits) ) 
-                round( x[[i]] , digits[names(x)[i]] ) 
-            else 
+    r <- as.data.frame(lapply( 1:length(x) ,
+        function(i) {
+            if ( names(x)[i] %in% names(digits) )
+                round( x[[i]] , digits[names(x)[i]] )
+            else
                 round(x[[i]], digits['default__'] );
         } ) )
     names(r) <- names(x)

--- a/R/z_link-map.r
+++ b/R/z_link-map.r
@@ -8,8 +8,8 @@ function( fit , data , n=1000 , ... ) {
 
 setMethod("link", "map",
 function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TRUE , ... ) {
-    
-    if ( class(fit)!="map" ) stop("Requires map fit")
+
+    if ( ! inherits(fit, "map")) stop("Requires map fit")
     if ( missing(data) ) {
         data <- fit@data
     } else {
@@ -17,21 +17,21 @@ function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TR
         # weird vectorization errors otherwise
         #data <- as.data.frame(data)
     }
-    
-    if ( missing(post) ) 
+
+    if ( missing(post) )
         post <- extract.samples(fit,n=n)
     else {
         n <- dim(post[[1]])[1]
         if ( is.null(n) ) n <- length(post[[1]])
     }
-    
+
     # replace with any elements of replace list
     if ( length( replace ) > 0 ) {
         for ( i in 1:length(replace) ) {
             post[[ names(replace)[i] ]] <- replace[[i]]
         }
     }
-    
+
     nlm <- length(fit@links)
     f_do_lm <- TRUE
     if ( nlm==0 ) {
@@ -40,14 +40,14 @@ function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TR
         nlm <- 1
         f_do_lm <- FALSE
     }
-    
+
     link_out <- vector(mode="list",length=nlm)
-    
+
     # for each linear model, compute value for each sample
     for ( i in 1:nlm ) {
         ref_inc <- floor(n*refresh)
         ref_next <- ref_inc
-        
+
         if ( f_do_lm==TRUE ) {
             parout <- fit@links[[i]][[1]]
             lm <- fit@links[[i]][[2]]
@@ -76,7 +76,7 @@ function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TR
                     if ( ref_next > n ) ref_next <- n
                 }
             }
-        
+
             # make environment
             init <- list() # holds one row of samples across all params
             for ( j in 1:length(post) ) {
@@ -96,12 +96,12 @@ function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TR
         link_out[[i]] <- value
         names(link_out)[i] <- parout
     }
-    
+
     if ( refresh>0 ) cat("\n")
-    
+
     if ( flatten==TRUE )
         if ( length(link_out)==1 ) link_out <- link_out[[1]]
-    
+
     return(link_out)
 }
 )

--- a/inst/rmarkdown/templates/rethinking-plain/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/rethinking-plain/skeleton/skeleton.Rmd
@@ -1,0 +1,32 @@
+---
+title: "Problem Set ??"
+author: "Your Name Here"
+date: "Stat 341 -- Spring 2017"
+output:
+  html_document:
+    fig_height: 2.5
+    fig_width: 3.5
+  pdf_document:
+    fig_height: 2.5
+    fig_width: 3.5
+  word_document:
+    fig_height: 2.5
+    fig_width: 3.5
+---
+
+```{r, setup, include=FALSE}
+# Load packages here 
+require(rethinking)
+require(mosaic)   
+require(ggformula)
+
+# Some customization.  You can alter or delete as desired (if you know what you are doing).
+trellis.par.set(theme=theme.mosaic()) # change default color scheme for lattice
+knitr::opts_chunk$set(
+  tidy=FALSE,     # display code as typed
+  size="small",   # slightly smaller font for code
+  fig.show = "hold")   # all plots at end of chunk
+theme_set(theme_minimal())
+```
+
+Delete this sentence and enter your text here.

--- a/inst/rmarkdown/templates/rethinking-plain/template.yaml
+++ b/inst/rmarkdown/templates/rethinking-plain/template.yaml
@@ -1,0 +1,4 @@
+name: rethinking plain
+description: >
+ Template for problem sets using rethinking package
+create_dir: false


### PR DESCRIPTION
This is an alternative to PR #69.

I haven't checked to see how different the solutions are, but both address the same main problem.  See Issue #57.

This PR also includes a few other tweaks:
  * `resid.map()` for computing residuals from a `map` object
  * `fitted.map()` for computing fitted values from a `map` object
  * `densify()` which converts values on a uniform grid to the density scale.  Use case: normalizing the posterior (or a prior)
  * turn on `LazyLoad` and `LazyData`
  * set `stringsAsFactors` to false when creating data frame in code for `precis()`.

Note: the new functions could use some documentation.  But the existing package (a) doesn't use roxygen and (b) is a long way from passing CRAN checks.  I'll if I can add some documentation soon -- likely via roxygen applied to just the files I modified.
