### PR TITLE
Wrong figure reference number on page 40

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -1,6 +1,8 @@
 Statistical Rethinking book Errata
 ==========
 
+page 40: Right above R code box 2.5, the text says that the different priors are replicated in FIGURE 2.5. The code in R code box  2.5 replicates the step and peaked prior in "FIGURE 2.6" (page 38), but not in "FIGURE 2.5" (page 30).
+
 page 42: Just below R code box 2.6, the text says that map requires a list of start values. It does not, as long as priors are provided for each parameter. And indeed the example in box 2.6 does not contain a list of start values.
 
 page 87: The marginal description of the model reads "mu ~ dnorm(156, 10)" but the model is Normal(178, 20). Same error on p 95 and in code 4.38. It is corrected in code 4.39.


### PR DESCRIPTION
text right above box with R code 2.5 refers to 'FIGURE 2.5' -> should be 'FIGURE 2.6'