### PR TITLE
Support for unit cumulative normal Phi()

### DIFF
--- a/R/map2stan.r
+++ b/R/map2stan.r
@@ -441,6 +441,17 @@ map2stan <- function( flist , data , start , pars , constraints=list() , types=l
         return(templates[[ tmpname ]])
     }
     
+    # Function to check if the current parameter is a prior or a vprior
+    # returns TRUE for a vprior, FALSE for a prior
+    is_vprior <- function(pname) {
+        any(sapply(fp$vprior, function(p){p$pars_out[[1]]}) == pname)
+    }    
+    
+    is_prior <- function(pname) {
+        any(sapply(fp$prior, function(p){p$par_out}) == pname)
+    }
+    
+    
     # build parsed list
     fp <- list( 
         likelihood = list() ,
@@ -474,8 +485,8 @@ map2stan <- function( flist , data , start , pars , constraints=list() , types=l
         result <- NULL
         if ( var %in% names(d) ) {
             type <- "real"
-            var_class <- class(d[[var]])
-            if ( var_class=="integer" ) type <- "int"
+            var_class <- class(d[[var]][[1]])
+            if ( var_class == "integer")  type <- "int"
             result <- list( var=var , N=N_name , type=type )
         }
         return(result)
@@ -901,9 +912,16 @@ map2stan <- function( flist , data , start , pars , constraints=list() , types=l
                 lhstxt <- tmplt$out_map( prior$par_out , prior$pars_in , environment() )
             }
             
-            # build text
-            txt <- concat( indent , lhstxt , " ~ " , prior$density , "( " , parstxt , " )" , prior$T_text , ";" )
+            # if the trans_pars_only tag was set on the template, don't include this parameter in the models section
             
+            if (is.null(templates[[prior$template]]$trans_pars_only) | !isTRUE(templates[[prior$template]]$trans_pars_only)){
+                # build text
+                txt <- concat( indent , lhstxt , " ~ " , prior$density , "( " , parstxt , " )" , prior$T_text , ";" )
+            } else {
+                txt <- ""
+            }
+            
+ 
             #m_model_priors <- concat( m_model_priors , txt , "\n" )
             m_model_txt <- concat( m_model_txt , txt , "\n" )
             
@@ -1036,12 +1054,17 @@ map2stan <- function( flist , data , start , pars , constraints=list() , types=l
             
             # add text to model code
             # new vectorized normal and multi_normal
+            
+            
             if ( vprior$density %in% c("multi_normal","normal") )
                 m_model_txt <- concat( m_model_txt , indent , lhstxt , " ~ " , vprior$density , "( " , rhstxt , " )" , vprior$T_text , ";\n" )
-            else
-            # old un-vectorized code
-                m_model_txt <- concat( m_model_txt , indent , "for ( j in 1:" , N_txt , " ) " , lhstxt , "[j] ~ " , vprior$density , "( " , rhstxt , " )" , vprior$T_text , ";\n" )
-            
+            else {
+                # check if this is a trans_pars_only vprior
+                if (is.null(tmplt$trans_pars_only) | !isTRUE(tmplt$trans_pars_only)) {
+                    # old un-vectorized code
+                    m_model_txt <- concat( m_model_txt , indent , "for ( j in 1:" , N_txt , " ) " , lhstxt , "[j] ~ " , vprior$density , "( " , rhstxt , " )" , vprior$T_text , ";\n" )
+                }
+            }
             # declare each parameter with correct type from template
             outtype <- "vector"
             for ( j in 1:length(vprior$pars_out) ) {
@@ -1548,8 +1571,22 @@ map2stan <- function( flist , data , start , pars , constraints=list() , types=l
                 }
             }
             
-            # add to parameters block
-            m_pars <- concat( m_pars , indent , type , constraint , type_dim , " " , pname , ";\n" )
+            
+            
+            # if the trans_pars_only tag was set on the template, don't include this parameter in the parameters section
+            
+            if (is_vprior(pname)) {
+                trans_pars_only = templates[[fp$vprior[[which(sapply(fp$vprior, function(p){p$pars_out[[1]]}) == pname)]]$template]]$trans_pars_only
+            } else if (is_prior(pname)) {
+                trans_pars_only = templates[[fp$prior[[ which(sapply(fp$prior,  function(p){p$par_out      }) == pname)]]$template]]$trans_pars_only
+            } else {
+                trans_pars_only <- NULL
+            }
+            
+            if (is.null(trans_pars_only) | !isTRUE(trans_pars_only)){
+                # add to parameters block
+                m_pars <- concat( m_pars , indent , type , constraint , type_dim , " " , pname , ";\n" )
+            }
         }#i
     }
     


### PR DESCRIPTION
It would be nice to be able to fit more not-just-linear-models in rethinking.
One domain is signal detection theory, where the unit cumulative normal function Phi() is used to infer backwards from hit and false alarm rates to for instance d prime and bias ([Lee, M.D. 2008.](https://www.researchgate.net/profile/Michael_Lee/publication/51398466_BayesSDT_Software_for_Bayesian_inference_with_signal_detection_theory/links/54fa9dce0cf20b0d2cb76660.pdf) for explanation and winBUGS implementation)

To do this we need Phi(), which already exists in stan, so I had a go at adding support for it here in rethinking.

stan needs Phi() in the transformed parameters{} section, so this commit works mostly by inserting stuff into transpars in the parent environment of par_map() and out_map() defined in the template.
However I also had to add another template tag `trans_pars_only` and insert code in map2stan.r to not redundantly try to declare the parameter in parameters{} and model{}. It shouldn't interfere with anything, if `trans_pars_only` is not defined, this commit doesn't change any behaviour in map2stan.r

What works:
 - Fitting hierachical ([example](https://github.com/stan-dev/example-models/blob/master/Bayesian_Cognitive_Modeling/CaseStudies/SignalDetection/SDT_2_Stan.R)) and non-hierachical models ([example](https://github.com/stan-dev/example-models/blob/master/Bayesian_Cognitive_Modeling/CaseStudies/SignalDetection/SDT_1_Stan.R)) signal detection models using Phi().
 - extract.samples
 - precis
 - trace plot

Not tested / doesn't work (for models with Phi())
- waic
- imputation
- link, sim, postcheck


```
devtools::install_github("maltelau/rethinking@Experimental")
library(rethinking)
library(dplyr)

data = data.frame(
    HIT = c(40, 35, 30, 10),
    FALSE_ALARM = c(30, 30, 20, 20),
    noise = c(50, 50, 45, 50),
    signal = c(50, 40, 50, 60),
    id = c(1,1,2,2)) %>%
    mutate_all(function(x){ array(as.integer(x), dim = length(x))})

sdt_hierachical <- map2stan(alist(
    HIT ~ dbinom(noise,  thetah[id]),
    FALSE_ALARM ~ dbinom(signal, thetaf[id]),
    thetah[id] ~ Phi( d[id] / 2 - c[id]),
    thetaf[id] ~ Phi(-d[id] / 2 - c[id]),
    d[id] ~ dnorm(d_mu, d_sigma),
    c[id] ~ dnorm(c_mu, c_sigma),
    d_mu ~ dnorm(0, 1),
    c_mu ~ dnorm(0, 1),
    d_sigma ~ dcauchy(0, 2),
    c_sigma ~ dcauchy(0, 2)
), data, WAIC = F)
```