### PR TITLE
Fixed link and sim for lm allow for more swift experiments

### DIFF
--- a/R/z_link_sim_methods.R
+++ b/R/z_link_sim_methods.R
@@ -26,7 +26,7 @@ function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TR
     if ( !missing(data) ) {
         model_orig <- fit$model
         out_var <- names(model_orig)[1] # first name should be outcome
-        data <- cbind( 0 , data )
+        data <- cbind( 0 , as.data.frame(data) )
         names(data)[1] <- out_var
         fit$model <- data
     }
@@ -63,7 +63,7 @@ function( fit , data , n=1000 , post , ll=FALSE , refresh=0.1 , ... ) {
     if ( !missing(data) ) {
         model_orig <- fit$model
         out_var <- names(model_orig)[1] # first name should be outcome
-        data <- cbind( 0 , data )
+        data <- cbind( 0 , as.data.frame(data) )
         names(data)[1] <- out_var
         fit$model <- data
     }


### PR DESCRIPTION
Thank you professor for the great lecture and this conveneint library for students to experiment with the data sets.

This pull request addressed a small problem, that if use lm of R instead of map or map2stan class from rethinking package the link and sim methods would not take input like `link(model, data=list(weight=weight.seq))`, because the original code assumed the data input to be a data.frame object. With the two forced conversion, humble lm can use the same link and sim methods with ease.
