### PR TITLE
misspelling of principal components analysis

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -11,6 +11,8 @@ page 103, R code 4.50: The ``post`` object implied here is the one from R code 4
 
 page 125: Below R code 5.4, "The posterior mean for age at marriage, ba, ..." 'ba' should be 'bA'.
 
+page 149: "PRINCIPLE COMPONENTS" -> "PRINCIPAL COMPONENTS"
+
 page 156, near top: "In fact, if you try to include a dummy variable for apes, you'll up with..." Should be "you'll end up with".
 
 page 196-200: The data.frame d has 17 cases. However in the discussion of the four models (on e.g. page 200), the text repeatedly refers to 12 cases.


### PR DESCRIPTION
Book makes common misspelling of "principle" but should say "principal components" as in the "most important components"