### PR TITLE
Fix model formula guessing in link-map

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rethinking
 Type: Package
 Title: Statistical Rethinking book package
-Version: 1.59
+Version: 1.59.1
 Date: 2016-6-24
 Author: Richard McElreath
 Maintainer: Richard McElreath <mcelreath@ucdavis.edu>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,5 +7,5 @@ Author: Richard McElreath
 Maintainer: Richard McElreath <mcelreath@ucdavis.edu>
 Imports: coda, MASS, mvtnorm, loo
 Depends: rstan (>= 2.10.0), parallel, methods, stats, graphics
-Description: Utilities for fitting and comparing models
+Description: Utilities for fitting and comparing models.
 License: GPL (>= 3)

--- a/R/z_link-map.r
+++ b/R/z_link-map.r
@@ -8,7 +8,7 @@ function( fit , data , n=1000 , ... ) {
 
 setMethod("link", "map",
 function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TRUE , ... ) {
-    
+
     if ( class(fit)!="map" ) stop("Requires map fit")
     if ( missing(data) ) {
         data <- fit@data
@@ -17,21 +17,21 @@ function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TR
         # weird vectorization errors otherwise
         #data <- as.data.frame(data)
     }
-    
-    if ( missing(post) ) 
+
+    if ( missing(post) )
         post <- extract.samples(fit,n=n)
     else {
         n <- dim(post[[1]])[1]
         if ( is.null(n) ) n <- length(post[[1]])
     }
-    
+
     # replace with any elements of replace list
     if ( length( replace ) > 0 ) {
         for ( i in 1:length(replace) ) {
             post[[ names(replace)[i] ]] <- replace[[i]]
         }
     }
-    
+
     nlm <- length(fit@links)
     f_do_lm <- TRUE
     if ( nlm==0 ) {
@@ -40,28 +40,28 @@ function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TR
         nlm <- 1
         f_do_lm <- FALSE
     }
-    
+
     link_out <- vector(mode="list",length=nlm)
-    
+
     # for each linear model, compute value for each sample
     for ( i in 1:nlm ) {
         ref_inc <- floor(n*refresh)
         ref_next <- ref_inc
-        
+
         if ( f_do_lm==TRUE ) {
             parout <- fit@links[[i]][[1]]
-            lm <- fit@links[[i]][[2]]
+            lm <- parse( text=fit@links[[i]][[2]] )
         } else {
             parout <- "ll"
             lm <- "0"
             # hacky solution -- find density function and insert whatever expression in typical link spot
-            flik <- as.character(fit@formula[[1]][[3]][[1]])
+            flik <- fit@formula[[1]][[3]][[1]]
             # mu for Gaussian
-            if ( flik=="dnorm" ) lm <- as.character( fit@formula[[1]][[3]][[2]] )
+            if ( flik=="dnorm" ) lm <- fit@formula[[1]][[3]][[2]]
             # p for binomial -- assume in third spot, after size
-            if ( flik=="dbinom" ) lm <- as.character( fit@formula[[1]][[3]][[3]] )
+            if ( flik=="dbinom" ) lm <- fit@formula[[1]][[3]][[3]]
             # lambda for poisson
-            if ( flik=="dpois" ) lm <- as.character( fit@formula[[1]][[3]][[2]] )
+            if ( flik=="dpois" ) lm <- fit@formula[[1]][[3]][[2]]
         }
         # empty matrix to hold samples-by-cases values of linear model
         value <- matrix(NA,nrow=n,ncol=length(data[[1]]))
@@ -76,7 +76,7 @@ function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TR
                     if ( ref_next > n ) ref_next <- n
                 }
             }
-        
+
             # make environment
             init <- list() # holds one row of samples across all params
             for ( j in 1:length(post) ) {
@@ -91,17 +91,17 @@ function( fit , data , n=1000 , post , refresh=0.1 , replace=list() , flatten=TR
             }#j
             e <- list( as.list(data) , as.list(init) )
             e <- unlist( e , recursive=FALSE )
-            value[s,] <- eval(parse(text=lm),envir=e)
+            value[s,] <- eval(lm,envir=e)
         }#s
         link_out[[i]] <- value
         names(link_out)[i] <- parout
     }
-    
+
     if ( refresh>0 ) cat("\n")
-    
+
     if ( flatten==TRUE )
         if ( length(link_out)==1 ) link_out <- link_out[[1]]
-    
+
     return(link_out)
 }
 )

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,7 +2,7 @@
 
 .onAttach <- function(...) {
   theLib <- dirname(system.file(package = "rethinking"))
-  pkgdesc <- packageDescription("rethinking", lib.loc = theLib)
+  pkgdesc <- utils::packageDescription("rethinking", lib.loc = theLib)
   builddate <- gsub(';.*$', '', pkgdesc$Packaged)
   msg <- paste("rethinking (Version ", pkgdesc$Version, ")", sep = "")
   packageStartupMessage(msg)


### PR DESCRIPTION
Formulas guessed for `map` objects with empty `links` slots were being mangled.  This patch fixes the problem.

The following test code verifies the fix:
```
data(Howell1)
d <- Howell1
d2 <- d[d$age >= 18,]

m4.3a <- map(
  alist(
    height ~ dnorm(mu,sigma),
    mu <- a + b*weight,
    a ~ dnorm(156, 100),
    b ~ dnorm(0, 10),
    sigma ~ dunif(0, 50)
  ),
  data = d2,
  start=list(a=156, b=0)
)

m4.3b <- map(
  alist(
    height ~ dnorm(a + b*weight, sigma),
    a ~ dnorm(156, 100),
    b ~ dnorm(0,10),
    sigma ~ dunif(0,50)
  ),
  data=d2,
  start=list(a=156, b=0)
)

## pick a fixed seed so that we can expect both link calls to generate the same values.
set.seed(8675309)
mua <- link(m4.3a)
set.seed(8675309)
mub <- link(m4.3b)

all.equal(mua, mub)         # Should return TRUE
```
