### PR TITLE
Adding tibble compatability for tidyverse compatibility

### DIFF
--- a/R/denschart.R
+++ b/R/denschart.R
@@ -22,7 +22,7 @@ denschart <- function (x, pars,
     par(cex = cex, yaxs = "i")
     if (class(x) %in% c("map2stan","map","stanfit")) {
         x <- extract.samples(x)
-        if ( class(x)=="data.frame" ) {
+        if ( inherits(x, "data.frame")) {
             x <- as.list(x)
             for ( i in 1:length(x) ) x[[i]] <- as.array(x[[i]])
         }

--- a/R/map-quap.r
+++ b/R/map-quap.r
@@ -37,7 +37,7 @@ quap <- function( flist , data , start , method="BFGS" , hessian=TRUE , debug=FA
     }
     if ( missing(start) ) start <- list()
     if ( missing(data) ) stop( "'data' required." )
-    if ( !( class(data) %in% c("list","data.frame") ) ) {
+    if ( !inherits(data, c("list","data.frame")) ) {
         stop( "'data' must be of class list or data.frame." )
     }
     

--- a/R/map2stan.r
+++ b/R/map2stan.r
@@ -76,7 +76,7 @@ map2stan <- function( flist , data , start , pars , constraints=list() , types=l
         }
     }
     if ( missing(data) ) stop( "'data' required." )
-    if ( !( class(data) %in% c("list","data.frame") ) ) {
+    if ( !inherits(data, c("list","data.frame")) ) {
         data <- try( as.list(data) , silent=TRUE )
         stop( "'data' must be a list, a data.frame, or coercable into a list." )
     }

--- a/R/plotting.r
+++ b/R/plotting.r
@@ -43,8 +43,7 @@ make.grid <- function( n ) {
 }
 
 dens <- function( x , adj=0.5 , norm.comp=FALSE , main="" , show.HPDI=FALSE , show.zero=FALSE , rm.na=TRUE , add=FALSE , ...) {
-    the.class <- class(x)[1]
-    if ( the.class=="data.frame" ) {
+    if ( inherits(x, "data.frame")) {
         # full posterior
         n <- ncol(x)
         cnames <- colnames(x)

--- a/R/utilities.r
+++ b/R/utilities.r
@@ -66,7 +66,7 @@ progbar <- function( current , min=0 , max=100 , starttime , update.interval=100
 covmat <- function( m , digits=4 ) {
     # upper diag is covariances
     # lower diag is correlations
-    if ( class(m)[1]=="data.frame" ) mcov <- cov( m ) else mcov <- vcov(m)
+    if ( inherits(m, "data.frame") ) mcov <- cov( m ) else mcov <- vcov(m)
     mcor <- cov2cor( mcov )
     mcov[ lower.tri(mcov) ] <- NA
     mcor[ lower.tri(mcor) ] <- NA
@@ -89,9 +89,8 @@ chainmode <- function( chain , ... ) {
 PIprimes <- c(0.67,0.89,0.97) # my snarky prime valued percentiles
 HPDI <- function( samples , prob=0.89 ) {
     # require(coda)
-    class.samples <- class(samples)[1]
     coerce.list <- c( "numeric" , "matrix" , "data.frame" , "integer" , "array" )
-    if ( class.samples %in% coerce.list ) {
+    if ( inherits(samples, coerce.list) ) {
         # single chain for single variable
         samples <- coda::as.mcmc( samples )
     }


### PR DESCRIPTION
Hey, 

I know you're old school R and don't use the `tidyverse` much, but many of us are very reliant and comfortable with it. It's definitely made working in R a lot nicer, but it does convert to it's own version of data.frame's, called tibbles, which are backwards compatible. Unfortunately, while tibble's act like data.frames, `rethinking` doesn't actually handle the class switching logic well.

This is because tibbles have multiple classes.
```R
> class(tibble())
[1] "tbl_df"     "tbl"        "data.frame"
```

and therefore, lines that use this logic
```R
> class(tibble()) == "data.frame"
[1] FALSE FALSE  TRUE
```
won't play nicely with if statements.

```
Error in quap(flist, dadult) :    
     'data' must be of class list or data.frame. 
In addition: Warning message: 
In if (!(class(data) %in% c("list", "data.frame"))) { :   
    the condition has length > 1 and only the first element will be used
```

I've switched the logic to be more `any` and `%in%` instead, so it will handle tibbles and treat them as data.frame's which is pretty consistent.

My changes to `precis` are similar, though you may want to approach the code in a different way, I've taken the simplest approach to the code, but this requires explicit handling of `tbl` while you may wish it to follow along the `data.frame` code path.
