### PR TITLE
Replace devtools with remotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ You'll need to install ``rstan`` first. Go to ``http://mc-stan.org`` and follow 
 
 Then you can install ``rethinking`` from within R using:
 ```
-install.packages(c("coda","mvtnorm","devtools","loo","dagitty"))
-library(devtools)
-devtools::install_github("rmcelreath/rethinking")
+install.packages(c("coda","mvtnorm","remotes","loo","dagitty"))
+library(remotes)
+remotes::install_github("rmcelreath/rethinking")
 ```
 If there are any problems, they likely arise when trying to install ``rstan``, so the ``rethinking`` package has little to do with it. See the manual linked above for some hints about getting ``rstan`` installed. But always consult the RStan section of the website at ``mc-stan.org`` for the latest information on RStan.
 


### PR DESCRIPTION
https://remotes.r-lib.org/
This package is a lightweight replacement of the install_* functions in devtools