### PR TITLE
Typo in 2nd Edition: peak vs peek

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -2,6 +2,8 @@
 
 ## 2nd Edition
 
+page 91, Overthinking box, third line: "Here's a peak at the motor" should be "Here's a peek at the motor".
+
 [to be filled]
 
 ## 1st Edition


### PR DESCRIPTION
Typo in 2nd Edition: page 91, Overthinking box, third line: "Here's a peak at the motor" should be "Here's a peek at the motor".