### PR TITLE
fixed issue in link not adding intercept for linear model (changed as…

### DIFF
--- a/R/z_link-map-quap.r
+++ b/R/z_link-map-quap.r
@@ -52,7 +52,7 @@ function( fit , data , n=1000 , post , refresh=0 , replace=list() , flatten=TRUE
             # hacky solution -- find density function and insert whatever expression in typical link spot
             flik <- as.character(fit@formula[[1]][[3]][[1]])
             # mu for Gaussian
-            if ( flik=="dnorm" ) lm <- as.character( fit@formula[[1]][[3]][[2]] )
+            if ( flik=="dnorm" ) lm <- deparse( fit@formula[[1]][[3]][[2]] )
             # p for binomial -- assume in third spot, after size
             if ( flik=="dbinom" ) lm <- as.character( fit@formula[[1]][[3]][[3]] )
             # lambda for poisson


### PR DESCRIPTION
I have not yet tried GLM, but it seems that for Gaussian linear models at using `as.character()` to parse the formula of the model result in an incorrect result.

Using this example:
```{r}
library(rethinking)
data(Howell1)
d<-Howell1
d2<-d[d$age>=18,]
m4.3 <- map(
  alist(
    height ~ dnorm( a + b*weight , sigma ) ,
    a ~ dnorm( 178 , 100) ,
    b ~ dnorm( 0 , 1) ,
    sigma ~ dunif( 0 , 50 )
  ),
  data=d2 )

mu <- link(m4.3, data=d2)
str(mu)
 num [1:1000, 1:352] 45.2 42.3 41 41.7 43.6 ...
```
Note that link give the predictions that are far from the actual values of heights

I tracked this down to the use of `as.character` 

```{r}
> as.character( m4.3@formula[[1]][[3]][[2]] )
[1] "+"          "a"          "b * weight"
```
Using `deparse`

```{r}
> deparse( m4.3@formula[[1]][[3]][[2]] )
[1] "a + b * weight"
```

After loading the new versions the numbers are correct

```{r}
> mu <- link(m4.3, data=d2)
> str(mu)
 num [1:1000, 1:352] 157 157 157 157 158 ...
```
