### PR TITLE
Fix the trim argument for traceplot_ulam()

### DIFF
--- a/R/ulam-class.R
+++ b/R/ulam-class.R
@@ -263,6 +263,8 @@ traceplot_ulam <- function( object , pars , chains , col=rethink_palette , alpha
             n_iter <- n_samples_extracted
         }
         window <- c(trim,n_iter)
+        wstart <- window[1]
+        wend <- window[2]
     }
     
     print(n_samples_extracted)


### PR DESCRIPTION
The trim argument currently does nothing, this fixes that bug, allowing traceplots to display correctly.

closes #321 