### PR TITLE
Remove reject column from UCBadmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ data( UCBadmit )
 UCBadmit$male <- as.integer(UCBadmit$applicant.gender=="male")
 UCBadmit$dept <- rep( 1:6 , each=2 )
 UCBadmit$applicant.gender <- NULL
+UCBadmit$reject <- NULL # reject clashes with a reserved keyword in Stan.
 
 # varying intercepts model
 m_glmm1 <- ulam(


### PR DESCRIPTION
The examples using UCBadmit gives an error with Stan 2.21.0. This is caused by the reject column in UCBadmit, as reject is apparently a reserved keyword in Stan.

```
Semantic error in '/tmp/RtmpLZPZxd/model-43b00def6d21.stan', line 2, column 8 to column 14:
   -------------------------------------------------
     1:  data{
     2:      int reject[12];
                 ^
     3:      int applications[12];
     4:      int admit[12];
   -------------------------------------------------

Identifier 'reject' clashes with reserved keyword.

make: *** [make/program:50: /tmp/RtmpLZPZxd/model-43b00def6d21.hpp] Error 1

Error: An error occured during compilation! See the message above for more information.
```