### PR TITLE
Debug diagnostic in sim_core signals error when model uses index variables

### DIFF
--- a/R/sim.r
+++ b/R/sim.r
@@ -17,7 +17,7 @@ sim_core <- function( fit , data , post , vars , n , refresh=0 , replace=list() 
         f <- fit@formula[[1]]
         for ( i in 1:length(fit@formula) ) {
             f <- fit@formula[[i]]
-            left <- as.character( f[[2]] )
+            left <- deparse( f[[2]] )
             if ( left==var ) {
                 if ( debug==TRUE ) print(f)
                 break


### PR DESCRIPTION
I'm having trouble using sim with models that have index variables.  Some debug code is crashing, and I think this may fix it.

Here is an example program that works after this change:
```
library(rethinking)

# Nancy Howell's Dobe !Kung data
data(Howell1)
d <- Howell1[Howell1$age >= 18, ]
d$sex <- d$male + 1

model5 <- alist(
    w ~ dnorm(mu, sigma),
    mu <- a[sex] + b[sex] * (h - hbar),
    a[sex] ~ dnorm(60, 10), # intercept: average adult weight in kg (wikipedia)
    b[sex] ~ dlnorm(0, 1),  # slope: change in weight per change in height
    sigma ~ dunif(0, 10),   # displacement

    h ~ dnorm(hmu, hsigma),
    hmu <- ha[sex],
    ha[sex] ~ dnorm(170, 15), # intercept: average adult height in cm
    hsigma ~ dunif(0, 10)      # displacement
)
dat <- list(w = d$weight, h = d$height,  hbar = mean(d$height), sex = d$sex)
fit5 <- quap(model5, data = dat)
precis(fit5, depth = 2)

# This is similar to McElreath 2022 Lecture 04, 49:39, but isn't working
hwsim <- sim(fit5, data = list(sex = c(1, 2), hbar = mean(d$height)),
     vars = c("h", "w"))
# seems to be dying in simcore because
# as.character turns a[s] into a vector c("[","a","s")
```