### PR TITLE
Adjust extract.samples to produce an appropriate data frame for n=1

### DIFF
--- a/R/map-quap-class.r
+++ b/R/map-quap-class.r
@@ -95,7 +95,11 @@ function( object , n=10000 , clean=TRUE , ... ) {
     } else {
         mu <- xcoef(object)
     }
-    result <- as.data.frame( mvrnorm( n=n , mu=mu , Sigma=vcov(object) ) )
+    if ( n==1 ) {
+      result <- as.data.frame( t( mvrnorm( n=n , mu=mu , Sigma=vcov(object) ) ) )
+    } else {
+      result <- as.data.frame( mvrnorm( n=n , mu=mu , Sigma=vcov(object) ) )
+    }
     if ( clean==TRUE ) {
         # convert (Intercept) to Intercept
         for ( i in 1:ncol(result) ) {
@@ -112,7 +116,11 @@ setMethod("extract.samples", "map",
 function(object,n=1e4,...){
     # require(MASS) # import now, so no need to require?
     mu <- object@coef
-    result <- as.data.frame( mvrnorm( n=n , mu=mu , Sigma=vcov(object) ) )
+     if ( n==1 ) {
+      result <- as.data.frame( t( mvrnorm( n=n , mu=mu , Sigma=vcov(object) ) ) )
+    } else {
+      result <- as.data.frame( mvrnorm( n=n , mu=mu , Sigma=vcov(object) ) )
+    }
     # convert vector parameters to vectors in list
     veclist <- attr(object,"veclist")
     name_head <- function(aname) strsplit( aname , "[" , fixed=TRUE )[[1]][1]


### PR DESCRIPTION
The change proposed here fixes the observation from Issue #369 
The solution is to transpose the vector produced by mvrnorm before transforming it into a data frame.