### PR TITLE
replace defunct 'as.real' call

### DIFF
--- a/R/coeftab.r
+++ b/R/coeftab.r
@@ -118,7 +118,7 @@ coeftab <- function( ... , se=FALSE , se.inside=FALSE , nobs=TRUE , digits=2 , w
                     d[i,][ paste(names(kse)[j],".se",sep="") ] <- as.numeric( round(kse[j],digits) )
                 else
                     # combine with estimate
-                    d[i,][ names(kse)[j] ] <- paste( formatC( (d[i,][ names(kse)[j] ]) , digits=digits ) , " (" , formatC( as.real( kse[j] ) , digits=digits ) , ")" , sep="" )
+                    d[i,][ names(kse)[j] ] <- paste( formatC( (d[i,][ names(kse)[j] ]) , digits=digits ) , " (" , formatC( as.double( kse[j] ) , digits=digits ) , ")" , sep="" )
             }
         }
     }


### PR DESCRIPTION
`as.real()` is likely `base::as.real()`, in which case it's been defunct since R 3.0.0 (i.e., roughly 10 years):

https://github.com/r-devel/r-svn/blob/03c59d2d9eff6d238d319669e83c75a1e4e4d8e0/src/library/base/man/base-defunct.Rd#L154-L157