### PR TITLE
fix UCBadmit demo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ data( UCBadmit )
 UCBadmit$male <- as.integer(UCBadmit$applicant.gender=="male")
 UCBadmit$dept <- rep( 1:6 , each=2 )
 UCBadmit$applicant.gender <- NULL
+UCBadmit$reject <- NULL
 
 # varying intercepts model
 m_glmm1 <- ulam(


### PR DESCRIPTION
The `reject` column leads to a Stan error: `Identifier 'reject' clashes with reserved keyword.`

```
Compiling Stan program...
Semantic error in 'C:/Users/Tristan/AppData/Local/Temp/RtmpANG1E7/model-43e43a135551.stan', line 3, column 18 to column 24:
   -------------------------------------------------
     1:  data{
     2:      array[12] int male;
     3:      array[12] int reject;
                           ^
     4:      array[12] int applications;
     5:      array[12] int admit;
   -------------------------------------------------

Identifier 'reject' clashes with reserved keyword.
```

Idk how much you rely on this variable name in the book, but this is a quick fix for the README.