### PR TITLE
Allow contour_xyz on non-square matrix

### DIFF
--- a/R/plotting.r
+++ b/R/plotting.r
@@ -120,7 +120,8 @@ contour_xyz <- function( x , y , z , ... ) {
     ux <- unique(x)
     uy <- unique(y)
     n <- length(ux)
-    m <- matrix( z , nrow=n , ncol=n )
+    ny <- length(uy)
+    m <- matrix( z , nrow=n , ncol=ny )
     contour( ux , uy , m , ... )
 }
 


### PR DESCRIPTION
Small change to allow contour_xyz plot also when x and y do not have the same dimension.