### PR TITLE
Fix saving and loading ulam() models when using cmdstanr; Fix log likelihood bugs for multi_normal outcome variables

### DIFF
--- a/R/ulam-function.R
+++ b/R/ulam-function.R
@@ -1037,7 +1037,9 @@ ulam <- function( flist , data , pars , pars_omit , start , chains=1 , cores=1 ,
                 # add by default
                 built <- compose_distibution( left_symbol , flist[[i]] , as_log_lik=TRUE )
                 m_gq2 <- concat( m_gq2 , built )
+                message(left_symbol)
                 N <- symbols[[left_symbol]]$dims[[2]]
+                message("Worked")
                 m_gq1 <- concat( m_gq1 , indent , "vector[" , N , "] log_lik;\n" )
                 # save N to attr so nobs/compare can get it later
                 nobs_save <- N

--- a/R/ulam-function.R
+++ b/R/ulam-function.R
@@ -1440,7 +1440,7 @@ ulam <- function( flist , data , pars , pars_omit , start , chains=1 , cores=1 ,
                     if ( rstanout==TRUE )
                         stanfit <- rstan::read_stan_csv(cmdstanfit$output_files())
                     else
-                        stanfit <- cmdstanfit
+                        stanfit <- read_cmdstan_csv(cmdstanfit$output_files())
                 }
             } else {
                 if ( cmdstan==FALSE ) {
@@ -1471,7 +1471,7 @@ ulam <- function( flist , data , pars , pars_omit , start , chains=1 , cores=1 ,
                     if ( rstanout==TRUE )
                         stanfit <- rstan::read_stan_csv(cmdstanfit$output_files())
                     else
-                        stanfit <- cmdstanfit
+                        stanfit <- read_cmdstan_csv(cmdstanfit$output_files())
                 }
             }
         } else {

--- a/R/ulam-function.R
+++ b/R/ulam-function.R
@@ -1440,7 +1440,7 @@ ulam <- function( flist , data , pars , pars_omit , start , chains=1 , cores=1 ,
                     if ( rstanout==TRUE )
                         stanfit <- rstan::read_stan_csv(cmdstanfit$output_files())
                     else
-                        stanfit <- read_cmdstan_csv(cmdstanfit$output_files())
+                        stanfit <- as_cmdstan_fit(cmdstanfit$output_files())
                 }
             } else {
                 if ( cmdstan==FALSE ) {
@@ -1471,7 +1471,7 @@ ulam <- function( flist , data , pars , pars_omit , start , chains=1 , cores=1 ,
                     if ( rstanout==TRUE )
                         stanfit <- rstan::read_stan_csv(cmdstanfit$output_files())
                     else
-                        stanfit <- read_cmdstan_csv(cmdstanfit$output_files())
+                        stanfit <- as_cmdstan_fit(cmdstanfit$output_files())
                 }
             }
         } else {

--- a/R/ulam-function.R
+++ b/R/ulam-function.R
@@ -1037,10 +1037,7 @@ ulam <- function( flist , data , pars , pars_omit , start , chains=1 , cores=1 ,
                 # add by default
                 built <- compose_distibution( left_symbol , flist[[i]] , as_log_lik=TRUE )
                 m_gq2 <- concat( m_gq2 , built )
-                message(left_symbol)
-                message(symbols)
-                N <- symbols[[left_symbol]]$dims[[2]]
-                message("Worked")
+                N <- symbols[[left_symbol[1]]]$dims[[2]]
                 m_gq1 <- concat( m_gq1 , indent , "vector[" , N , "] log_lik;\n" )
                 # save N to attr so nobs/compare can get it later
                 nobs_save <- N

--- a/R/ulam-function.R
+++ b/R/ulam-function.R
@@ -1037,6 +1037,7 @@ ulam <- function( flist , data , pars , pars_omit , start , chains=1 , cores=1 ,
                 # add by default
                 built <- compose_distibution( left_symbol , flist[[i]] , as_log_lik=TRUE )
                 m_gq2 <- concat( m_gq2 , built )
+                message(left_symbol)
                 message(symbols)
                 N <- symbols[[left_symbol]]$dims[[2]]
                 message("Worked")

--- a/R/ulam-function.R
+++ b/R/ulam-function.R
@@ -1037,7 +1037,7 @@ ulam <- function( flist , data , pars , pars_omit , start , chains=1 , cores=1 ,
                 # add by default
                 built <- compose_distibution( left_symbol , flist[[i]] , as_log_lik=TRUE )
                 m_gq2 <- concat( m_gq2 , built )
-                message(left_symbol)
+                message(symbols)
                 N <- symbols[[left_symbol]]$dims[[2]]
                 message("Worked")
                 m_gq1 <- concat( m_gq1 , indent , "vector[" , N , "] log_lik;\n" )

--- a/R/ulam_templates.R
+++ b/R/ulam_templates.R
@@ -472,7 +472,9 @@ ulam_dists <- list(
                 out <- concat( out , indent , out_var , " ~ multi_normal( " , MU_var , " , " , SIGMA , " );\n" )
 
             } else {
-                out <- concat( out , indent , "log_lik = multi_normal_lpdf( " , out_var , " | " , MU_var , " , " , SIGMA , " );\n" )
+                out <- concat( out , indent , "for ( j in 1:" , n_cases , " ) {\n" )
+                out <- concat( out , indent , indent , "log_lik[j] = multi_normal_lpdf( " , out_var , "[j] | " , MU_var , "[j] , " , SIGMA , " );\n" )
+                out <- concat( out , indent , "}\n" )
             }
 
             # close local environment, if necessary


### PR DESCRIPTION
By default, **cmdstanr** saves model output in temporary files and only loads that data into memory when it is required. This means that when a fitted model is written to a file, a lot of data is not included in that file. So when the current R session is exited, the temporary files are deleted, and the fitted models can no longer be fully loaded. See example code below:

```R
> library(rethinking)
Loading required package: cmdstanr
This is cmdstanr version 0.7.1
- CmdStanR documentation and vignettes: mc-stan.org/cmdstanr
- CmdStan path: /vol/customopt/cmdstan-2.34.1
- CmdStan version: 2.34.1

> fit_stan <- ulam(
    alist(
        y ~ dnorm( mu , sigma ),
        mu ~ dnorm( 0 , 10 ),
        sigma ~ dexp( 1 )
    ), data=list(y=c(-1,1)), file = "test"
)
Compiling Stan program...
Running MCMC with 1 chain, with 1 thread(s) per chain...

Chain 1 Iteration:   1 / 1000 [  0%]  (Warmup)
Chain 1 Iteration: 100 / 1000 [ 10%]  (Warmup)
Chain 1 Iteration: 200 / 1000 [ 20%]  (Warmup)
Chain 1 Iteration: 300 / 1000 [ 30%]  (Warmup)
Chain 1 Iteration: 400 / 1000 [ 40%]  (Warmup)
Chain 1 Iteration: 500 / 1000 [ 50%]  (Warmup)
Chain 1 Iteration: 501 / 1000 [ 50%]  (Sampling)
Chain 1 Iteration: 600 / 1000 [ 60%]  (Sampling)
Chain 1 Iteration: 700 / 1000 [ 70%]  (Sampling)
Chain 1 Iteration: 800 / 1000 [ 80%]  (Sampling)
Chain 1 Iteration: 900 / 1000 [ 90%]  (Sampling)
Chain 1 Iteration: 1000 / 1000 [100%]  (Sampling)
Chain 1 finished in 0.0 seconds.
Saving result as test.rds

# Temporary files still exist, so we can access our model data:
> precis(fit_stan)
       mean   sd  5.5% 94.5% rhat ess_bulk
mu    -0.12 1.06 -1.91  1.46 1.00   159.00
sigma  1.43 0.79  0.60  2.75 1.01   169.57

> q()

# however when we exit and start a new session:

> library(rethinking)
> fit_stan <- readRDS("test.rds")
> precis(fit_stan)
Error in read_cmdstan_csv(files = self$output_files(include_failed = FALSE),  :
  Assertion on 'files' failed: File does not exist: '/scratch/RtmpDWbuV6/ulam_cmdstanr_8b4a70079e6636864e593d38ad729313-202403191850-1-5b97c7.csv'.
```

The fix consists of two lines of code, and was inspired by these relevant pages:
https://discourse.mc-stan.org/t/error-in-read-cmdstan-csv-assertion-on-files-failed/30150
https://mc-stan.org/cmdstanr/reference/read_cmdstan_csv.html
https://mc-stan.org/cmdstanr/reference/fit-method-save_output_files.html

Using `stanfit <- as_cmdstan_fit(cmdstanfit$output_files())` we assign the data from the temporary files to `stanfit` and store the data inside the ulam object.

Using this fix, the example code works:
```R
> library(rethinking)
> fit_ulam <- readRDS("test.rds")
> precis(fit_ulam)
       mean   sd  5.5% 94.5% rhat ess_bulk
mu    -0.03 0.95 -1.62  1.31    1   218.40
sigma  1.53 0.72  0.72  2.88    1   100.27
```

This was tested on: 
- Ubuntu 22.04 LTS
- R 4.1.2
- CmdStan 2.34.1
- cmdstanr 0.7.1
- latest rethinking code